### PR TITLE
feat: standalone check for telemetry enabled

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,8 +1,8 @@
 {
-    "require": "ts-node/register,source-map-support/register",
-    "watch-extensions": "ts",
-    "recursive": true,
-    "reporter": "spec",
-    "timeout": 5000
-  }
-  
+  "require": "ts-node/register,source-map-support/register",
+  "watch-extensions": "ts",
+  "watch-files": ["src/**/*.ts", "test/**/*.ts"],
+  "recursive": true,
+  "reporter": "spec",
+  "timeout": 5000
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "4.0.16",
   "description": "Library for application insights",
   "main": "lib/exported",
+  "exports": {
+    "./enabledCheck": "./lib/enabledCheck.js",
+    ".": "./lib/exported.js"
+  },
   "repository": "forcedotcom/telemetry",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/src/enabledCheck.ts
+++ b/src/enabledCheck.ts
@@ -19,7 +19,7 @@ let enabled: boolean | undefined;
  * memoized: only runs once
  *
  * */
-export const isEnabled = async (configAggregator?: ConfigAggregator) => {
+export const isEnabled = async (configAggregator?: ConfigAggregator): Promise<boolean> => {
   if (enabled === undefined) {
     const agg = configAggregator ?? (await ConfigAggregator.create({}));
     enabled = agg.getPropertyValue<string>(SfConfigProperties.DISABLE_TELEMETRY) !== 'true';

--- a/src/enabledCheck.ts
+++ b/src/enabledCheck.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// deep imports to avoid requiring the ENTIRE package (which will also pull in jsforce) until we get ESM done
+import { ConfigAggregator } from '@salesforce/core/lib/config/configAggregator';
+import { SfConfigProperties } from '@salesforce/core/lib/config/config';
+
+// store the result to reduce checks
+let enabled: boolean | undefined;
+
+/**
+ *
+ * Check ConfigAggregator once for telemetry opt-out.  Returns true unless config/env has opt-out
+ * If you don't pass in a ConfigAggregator, one will be constructed for you
+ * memoized: only runs once
+ *
+ * */
+export const isEnabled = async (configAggregator?: ConfigAggregator) => {
+  if (enabled === undefined) {
+    const agg = configAggregator ?? (await ConfigAggregator.create({}));
+    enabled = agg.getPropertyValue<string>(SfConfigProperties.DISABLE_TELEMETRY) !== 'true';
+  }
+  return enabled;
+};

--- a/src/exported.ts
+++ b/src/exported.ts
@@ -9,4 +9,5 @@
 import { TelemetryReporter } from './telemetryReporter';
 
 export * from './telemetryReporter';
+export { isEnabled } from './enabledCheck';
 export default TelemetryReporter;

--- a/test/unit/telemetryReporter.test.ts
+++ b/test/unit/telemetryReporter.test.ts
@@ -11,6 +11,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { AppInsights } from '../../src/appInsights';
 import { TelemetryReporter } from '../../src/telemetryReporter';
+import * as enabledStubs from '../../src/enabledCheck';
 
 describe('TelemetryReporter', () => {
   const key = 'foo-bar-123';
@@ -75,7 +76,7 @@ describe('TelemetryReporter', () => {
   });
 
   it('should not send a telemetry event when disabled', async () => {
-    sandbox.stub(ConfigAggregator.prototype, 'getPropertyValue').returns('true');
+    sandbox.stub(enabledStubs, 'isEnabled').resolves(false);
     const options = { project, key };
     const reporter = await TelemetryReporter.create(options);
     const sendStub = sandbox.stub(reporter.getTelemetryClient(), 'trackEvent').callsFake(() => {});
@@ -85,7 +86,7 @@ describe('TelemetryReporter', () => {
   });
 
   it('should not send a telemetry exception when disabled', async () => {
-    sandbox.stub(ConfigAggregator.prototype, 'getPropertyValue').returns('true');
+    sandbox.stub(enabledStubs, 'isEnabled').resolves(false);
     const options = { project, key };
     const reporter = await TelemetryReporter.create(options);
     const sendStub = sandbox.stub(reporter.getTelemetryClient(), 'trackException').callsFake(() => {});
@@ -95,7 +96,7 @@ describe('TelemetryReporter', () => {
   });
 
   it('should not send a telemetry trace when disabled', async () => {
-    sandbox.stub(ConfigAggregator.prototype, 'getPropertyValue').returns('true');
+    sandbox.stub(enabledStubs, 'isEnabled').resolves(false);
     const options = { project, key };
     const reporter = await TelemetryReporter.create(options);
     const sendStub = sandbox.stub(reporter.getTelemetryClient(), 'trackTrace').callsFake(() => {});
@@ -105,7 +106,7 @@ describe('TelemetryReporter', () => {
   });
 
   it('should not send a telemetry metric when disabled', async () => {
-    sandbox.stub(ConfigAggregator.prototype, 'getPropertyValue').returns('true');
+    sandbox.stub(enabledStubs, 'isEnabled').resolves(false);
     const options = { project, key };
     const reporter = await TelemetryReporter.create(options);
     const sendStub = sandbox.stub(reporter.getTelemetryClient(), 'trackMetric').callsFake(() => {});
@@ -115,7 +116,7 @@ describe('TelemetryReporter', () => {
   });
 
   it('should log to enable telemetry metric when disabled', async () => {
-    sandbox.stub(ConfigAggregator.prototype, 'getPropertyValue').returns('true');
+    sandbox.stub(enabledStubs, 'isEnabled').resolves(false);
     const warn = sandbox.stub();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
     sandbox.stub(Logger, 'child').resolves({ warn, debug: sandbox.stub() } as any);


### PR DESCRIPTION
### What does this PR do?
if you want to check if telemetry is enabled, there were a lot of perf-killing side effects
- requiring appInsights
- configAgg => all of sfdx-core => all of jsforce

This change
- do the enabled check in a standalone function that memoizes the result
- put the `enabledCheck` as a top-level export. You can import just that instead of all of exported.ts
- re-use the memoized check in the telemetryReporter class, removing the static OOP tricks needed used to persist that state (and deprecate the static method)
- since some methods aren't async, store the result in the class so sync instance methods can access it 

No breaking changes intended.  Verify that the pjson `exports` prop doesn't break consumers.

### What issues does this PR fix or reference?
@W-13931029@

QA: I shipped a CLI prerel to validate with (`2.5.2-qa.0`)
verify things are still getting to AppInsights (hint: search using your cliid)

run `DEBUG=perf sf config list` a few times, looking for something like `@salesforce/plugin-telemetry(./lib/hooks/telemetryPrerun.js): 312.1893ms`


